### PR TITLE
Fix running with no arguments

### DIFF
--- a/exonum_launcher/__main__.py
+++ b/exonum_launcher/__main__.py
@@ -21,8 +21,10 @@ def run() -> None:
     parser_run.set_defaults(func=prepare_launcher)
 
     args = parser.parse_args()
-
-    args.func(args)
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
 
 
 def prepare_launcher(args):


### PR DESCRIPTION
As for now, if you'll try to run module with no arguments, e.g. `python -m exonum_launcher`, you'll get an error:

```sh
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/popzxc/workspace/launcher/exonum-launcher/exonum_launcher/__main__.py", line 35, in <module>
    run()
  File "/home/popzxc/workspace/launcher/exonum-launcher/exonum_launcher/__main__.py", line 25, in run
    args.func(args)
AttributeError: 'Namespace' object has no attribute 'func'
```

This PR fixes it, so the help output will be printed.