### PR TITLE
Add plugin system [ECR-3622, ECR-3623, ECR-3624]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Proto directory
-proto
+# Proto files
+*_pb2.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict, List
 import yaml
 
-RUNTIMES = {"rust": 0}
+RUNTIMES = {"rust": 0, "python": 2}
 
 
 class Artifact:
@@ -11,7 +11,7 @@ class Artifact:
     @staticmethod
     def from_dict(data: Dict[Any, Any]) -> "Artifact":
         """Parses an `Artifact` entity from provided dict."""
-        return Artifact(name=data["name"], runtime=data["runtime"], spec=data.get("spec", None))
+        return Artifact(name=data["name"], runtime=data["runtime"], spec=data.get("spec", dict()))
 
     def __init__(self, name: str, runtime: str, spec: Any) -> None:
         self.name = name

--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -2,7 +2,7 @@
 from typing import Any, Dict, List
 import yaml
 
-RUNTIMES = {"rust": 0, "python": 2}
+RUNTIMES = {"rust": 0}
 
 
 class Artifact:
@@ -53,6 +53,11 @@ class Configuration:
             raise ValueError(f"Runtime {runtime} is already declared (it has id {RUNTIMES[runtime]})")
 
         RUNTIMES[runtime] = runtime_id
+
+    @staticmethod
+    def runtimes() -> Dict[str, int]:
+        """Returns a list of added runtimes."""
+        return RUNTIMES
 
     @staticmethod
     def from_yaml(path: str) -> "Configuration":

--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -42,6 +42,19 @@ class Configuration:
     """Parsed configuration of services to deploy&init."""
 
     @staticmethod
+    def declare_runtime(runtime: str, runtime_id: int) -> None:
+        """With this method you can declare an additional runtime, for example:
+
+        >>> Configuration.declare_runtime("java", 1)
+
+        Please note that this method should be called before config parsing.
+        """
+        if runtime in RUNTIMES:
+            raise ValueError(f"Runtime {runtime} is already declared (it has id {RUNTIMES[runtime]})")
+
+        RUNTIMES[runtime] = runtime_id
+
+    @staticmethod
     def from_yaml(path: str) -> "Configuration":
         """Parses configuration from YAML file."""
         data = load_yaml(path)

--- a/exonum_launcher/instances/__init__.py
+++ b/exonum_launcher/instances/__init__.py
@@ -1,0 +1,4 @@
+"""Module containing instance config serializers"""
+
+from .instance_spec_loader import InstanceSpecLoader, InstanceSpecLoadError
+from .default_spec_loader import DefaultInstanceSpecLoader

--- a/exonum_launcher/instances/default_spec_loader.py
+++ b/exonum_launcher/instances/default_spec_loader.py
@@ -1,0 +1,43 @@
+"""Default spec loader which will be attempted to be used in case
+if concrete loader was not provided for artifact."""
+
+from exonum_client.protobuf_loader import ProtobufLoader
+from exonum_client.module_manager import ModuleManager
+from exonum_client.proofs.encoder import build_encoder_function
+
+from exonum_launcher.configuration import Instance
+
+from .instance_spec_loader import InstanceSpecLoader, InstanceSpecLoadError
+
+
+class DefaultInstanceSpecLoader(InstanceSpecLoader):
+    """Default spec loader.
+    It attempts to load artifact proto files and recursively merge
+    Config message from provided instance config dict."""
+
+    def load_spec(self, loader: ProtobufLoader, instance: Instance) -> bytes:
+        try:
+            try:
+                # Try to load module (if it's already compiled) first.
+                service_module = ModuleManager.import_service_module(instance.artifact.name, "service")
+            except (ModuleNotFoundError, ImportError):
+                # If it's not compiled, load & compile protobuf.
+                loader.load_service_proto_files(instance.artifact.runtime_id, instance.artifact.name)
+                service_module = ModuleManager.import_service_module(instance.artifact.name, "service")
+
+            config_class = service_module.Config
+
+            # `build_encoder_function` will create a recursive binary serializer for the
+            # provided message type. In our case we want to serialize `Config`.
+            config_encoder = build_encoder_function(config_class)
+            result = config_encoder(instance.config)
+
+        # We're catching all the exceptions to shutdown gracefully (on the caller side) just in case.
+        # pylint: disable=broad-except
+        except Exception as error:
+            artifact_name = instance.artifact.name
+            raise InstanceSpecLoadError(
+                f"Couldn't get a proto description for artifact: {artifact_name}, error: {error}"
+            )
+
+        return result

--- a/exonum_launcher/instances/instance_spec_loader.py
+++ b/exonum_launcher/instances/instance_spec_loader.py
@@ -1,0 +1,20 @@
+"""TODO"""
+
+import abc
+
+from exonum_client.protobuf_loader import ProtobufLoader
+
+from exonum_launcher.configuration import Instance
+
+
+class InstanceSpecLoadError(Exception):
+    """Exception that should be raised if config load failed."""
+
+
+class InstanceSpecLoader(metaclass=abc.ABCMeta):
+    """Base class for custom instance spec loaders."""
+
+    @abc.abstractmethod
+    def load_spec(self, loader: ProtobufLoader, instance: Instance) -> bytes:
+        """This method gets an instance spec and Protobuf Loader object and
+        must provide instance spec serialized to bytes."""

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -12,7 +12,7 @@ from exonum_client import ExonumClient, ModuleManager
 from exonum_client.protobuf_loader import ProtobufLoader
 
 from .configuration import Artifact, Configuration, Instance
-from .runtimes import RuntimeSpecLoader, RustSpecLoader, PythonSpecLoader
+from .runtimes import RuntimeSpecLoader, RustSpecLoader
 from .instances import DefaultInstanceSpecLoader, InstanceSpecLoader, InstanceSpecLoadError
 
 
@@ -65,7 +65,13 @@ class Launcher:
         self._completed_deployments: List[Artifact] = []
         self._completed_initializations: List[Instance] = []
 
-        self._runtime_spec_loaders = {"rust": RustSpecLoader(), "python": PythonSpecLoader()}
+        self._runtime_spec_loaders: Dict[str, RuntimeSpecLoader] = {"rust": RustSpecLoader()}
+
+        if "python" in Configuration.runtimes():
+            from .runtimes.python import PythonSpecLoader
+
+            self._runtime_spec_loaders["python"] = PythonSpecLoader()
+
         self._instance_spec_loaders: Dict[Artifact, InstanceSpecLoader] = dict()
 
         self._supervisor_runtime_id = 0

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -11,8 +11,9 @@ from google.protobuf.message import Message as ProtobufMessage
 from exonum_client import ExonumClient, ModuleManager
 from exonum_client.protobuf_loader import ProtobufLoader
 
-# from .client import SupervisorClient
 from .configuration import Artifact, Configuration, Instance
+from .runtimes import RuntimeSpecLoader, RustSpecLoader, PythonSpecLoader
+from .instances import DefaultInstanceSpecLoader, InstanceSpecLoader, InstanceSpecLoadError
 
 
 def _msg_to_hex(msg: ProtobufMessage) -> str:
@@ -64,6 +65,9 @@ class Launcher:
         self._completed_deployments: List[Artifact] = []
         self._completed_initializations: List[Instance] = []
 
+        self._runtime_spec_loaders = {"rust": RustSpecLoader(), "python": PythonSpecLoader()}
+        self._instance_spec_loaders: Dict[Artifact, InstanceSpecLoader] = dict()
+
         self._supervisor_runtime_id = 0
         self._supervisor_artifact_name = ""
         self.service_module: Optional[Any] = None
@@ -96,7 +100,7 @@ class Launcher:
                 self._supervisor_artifact_name = artifact["name"]
                 break
 
-        if self._supervisor_artifact_name != "":
+        if self._supervisor_artifact_name == "":
             raise RuntimeError(
                 "Could not find exonum-supervisor in available artifacts."
                 "Please check that exonum node configuration is correct"
@@ -108,6 +112,20 @@ class Launcher:
     def deinitialize(self) -> None:
         """Deinitializes the Launcher by deinitializing the Protobuf Loader."""
         self.loader.deinitialize()
+
+    def add_runtime_spec_loader(self, runtime: str, spec_loader: RuntimeSpecLoader) -> None:
+        """Adds a runtime-specific spec loader to encode runtime artifact spec into bytes."""
+        if runtime in self._runtime_spec_loaders:
+            raise ValueError(f"Spec loader for runtime '{runtime}' is already added")
+
+        self._runtime_spec_loaders[runtime] = spec_loader
+
+    def add_instance_spec_loader(self, artifact: Artifact, spec_loader: InstanceSpecLoader) -> None:
+        """Adds an artifact-specific config spec loader to encode instance configs into bytes."""
+        if artifact in self._instance_spec_loaders:
+            raise ValueError(f"Instance spec loader for artifact '{artifact.name}' is already added")
+
+        self._instance_spec_loaders[artifact] = spec_loader
 
     def supervisor_data(self) -> Tuple[int, str]:
         """Returns a tuple of supervisor instance ID and name."""
@@ -176,14 +194,13 @@ class Launcher:
         if self.service_module is None:
             raise RuntimeError("Launcher is not initialized")
 
-        for _, artifact in self.config.artifacts.items():
+        for artifact in self.config.artifacts.values():
             deploy_request = self.service_module.DeployRequest()
 
-            # TODO add spec to the request.
             deploy_request.artifact.runtime_id = artifact.runtime_id
             deploy_request.artifact.name = artifact.name
             deploy_request.deadline_height = artifact.deadline_height
-            # deploy_request.spec = ???
+            deploy_request.spec = self._runtime_spec_loaders[artifact.runtime].encode_spec(artifact.spec)
 
             self._pending_deployments[artifact] = self._post_to_supervisor("deploy-artifact", deploy_request)
 
@@ -212,15 +229,14 @@ class Launcher:
         for instance in self.config.instances:
             start_request = self.service_module.StartService()
 
-            # TODO add config to the request.
             start_request.artifact.runtime_id = instance.artifact.runtime_id
             start_request.artifact.name = instance.artifact.name
             start_request.name = instance.name
             start_request.deadline_height = instance.deadline_height
 
             if instance.config:
-                config = self.get_service_config(instance)
-                start_request.config.Pack(config)
+                spec_loader = self._instance_spec_loaders.get(instance.artifact, DefaultInstanceSpecLoader())
+                start_request.config = spec_loader.load_spec(self.loader, instance)
 
             self._pending_initializations[instance] = self._post_to_supervisor("start-service", start_request)
 
@@ -261,29 +277,6 @@ class Launcher:
                 return value["id"]
 
         return None
-
-    def get_service_config(self, instance: Instance) -> ProtobufMessage:
-        """Loads the artifact proto files for provided instance,
-        gets Config message and fills it.
-        Returns a filled Protobuf Message object."""
-
-        try:
-            self.loader.load_service_proto_files(instance.artifact.runtime_id, instance.artifact.name)
-            service_module = ModuleManager.import_service_module(instance.artifact.name, "service")
-
-        # We're catchin all the exceptions to shutdown gracefully just in case.
-        # pylint: disable=broad-except
-        except Exception as error:
-            print("Couldn't get a proto description for artifact: {}, error: {}".format(instance.artifact.name, error))
-            sys.exit(1)
-
-        config = service_module.Config()
-
-        for key, value in instance.config.items():
-            assert key in config.DESCRIPTOR.fields_by_name.keys()
-            setattr(config, key, value)
-
-        return config
 
 
 def main(args: Any) -> None:

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -241,8 +241,12 @@ class Launcher:
             start_request.deadline_height = instance.deadline_height
 
             if instance.config:
-                spec_loader = self._instance_spec_loaders.get(instance.artifact, DefaultInstanceSpecLoader())
-                start_request.config = spec_loader.load_spec(self.loader, instance)
+                try:
+                    spec_loader = self._instance_spec_loaders.get(instance.artifact, DefaultInstanceSpecLoader())
+                    start_request.config = spec_loader.load_spec(self.loader, instance)
+                except InstanceSpecLoadError as error:
+                    print(f"Error occured during spec loading: {error}")
+                    sys.exit(1)
 
             self._pending_initializations[instance] = self._post_to_supervisor("start-service", start_request)
 

--- a/exonum_launcher/runtimes/__init__.py
+++ b/exonum_launcher/runtimes/__init__.py
@@ -1,4 +1,3 @@
 """`runtimes` module contains artifact spec encoders for different runtimes."""
 from .runtime import RuntimeSpecLoader
 from .rust import RustSpecLoader
-from .python import PythonSpecLoader

--- a/exonum_launcher/runtimes/__init__.py
+++ b/exonum_launcher/runtimes/__init__.py
@@ -1,0 +1,4 @@
+"""`runtimes` module contains artifact spec encoders for different runtimes."""
+from .runtime import RuntimeSpecLoader
+from .rust import RustSpecLoader
+from .python import PythonSpecLoader

--- a/exonum_launcher/runtimes/proto/python.proto
+++ b/exonum_launcher/runtimes/proto/python.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package exonum.python.runtime;
+
+// Python artifact spec.
+message PythonArtifactSpec {
+    // Name of the source wheel file.
+    string source_wheel_name = 1;
+    // Service library name (it will be used to import service module).
+    string service_library_name = 2;
+    // Name of the service class to be imported from the library.
+    string service_class_name = 3;
+    // Expected hash of the artifact.
+    bytes hash = 4;
+}

--- a/exonum_launcher/runtimes/python.py
+++ b/exonum_launcher/runtimes/python.py
@@ -1,0 +1,25 @@
+"""Artifact spec encoder for Python runtime"""
+
+from typing import Dict, Any
+
+from .runtime import RuntimeSpecLoader
+
+try:
+    from .proto import python_pb2
+except (ModuleNotFoundError, ImportError):
+    raise RuntimeError("You should compile .proto files before usage")
+
+
+class PythonSpecLoader(RuntimeSpecLoader):
+    """Artifact spec encoder for Python runtime"""
+
+    def encode_spec(self, data: Dict[str, Any]) -> bytes:
+        # Rust artifacts do not have spec
+        spec = python_pb2.PythonArtifactSpec()
+
+        spec.source_wheel_name = data["source_wheel_name"]
+        spec.service_library_name = data["service_library_name"]
+        spec.service_class_name = data["service_class_name"]
+        spec.hash = bytes.fromhex(data["hash"])
+
+        return spec.SerializeToString()

--- a/exonum_launcher/runtimes/python.py
+++ b/exonum_launcher/runtimes/python.py
@@ -1,4 +1,12 @@
-"""Artifact spec encoder for Python runtime"""
+"""Artifact spec encoder for Python runtime.
+
+To get it working, you should first compile `.proto` files:
+
+```sh
+cd exonum_launcher/runtimes/proto
+protoc --proto_path=. --python_out=. python.proto
+```
+"""
 
 from typing import Dict, Any
 

--- a/exonum_launcher/runtimes/runtime.py
+++ b/exonum_launcher/runtimes/runtime.py
@@ -1,0 +1,11 @@
+"""Module with RuntimeSpecLoader class"""
+import abc
+from typing import Dict, Any
+
+
+class RuntimeSpecLoader(metaclass=abc.ABCMeta):
+    """Interface for classes loading artifact spec"""
+
+    @abc.abstractmethod
+    def encode_spec(self, data: Dict[str, Any]) -> bytes:
+        """Encodes provided runtime-specific artifact spec into bytes."""

--- a/exonum_launcher/runtimes/rust.py
+++ b/exonum_launcher/runtimes/rust.py
@@ -1,0 +1,13 @@
+"""Artifact spec encoder for Rust runtime"""
+
+from typing import Dict, Any
+
+from .runtime import RuntimeSpecLoader
+
+
+class RustSpecLoader(RuntimeSpecLoader):
+    """Artifact spec encoder for Rust runtime"""
+
+    def encode_spec(self, data: Dict[str, Any]) -> bytes:
+        # Rust artifacts do not have spec
+        return b""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ class TestConfiguration(unittest.TestCase):
         self.assertEqual(cryptocurrency.runtime, "rust")
         self.assertEqual(cryptocurrency.runtime_id, 0)
         self.assertEqual(cryptocurrency.deadline_height, 10000)
-        self.assertIsNone(cryptocurrency.spec)
+        self.assertEqual(cryptocurrency.spec, {})
 
         self.assertEqual(len(config.instances), 2)
 


### PR DESCRIPTION
tl;dr: with this PR merged you can add support of custom runtimes and create custom config loaders for instances.

Full description:
This PR introduces a plugin system with the following concrete features:

- Declaring new runtimes by calling `Configuration.declare_runtime(runtime_name, runtime_id)`.

- Runtime-specific artifact spec loaders. You can implement spec loader for your runtime by inheriting `RuntimeSpecLoader` base class, and then provide it to `Launcher` with `add_runtime_spec_loader` method. Launcher then will use this loader to encode runtime-specific artifact spec into payload.

- Artifact-specific instance config loaders. Same as artifact spec loader, but you can create loader specifig to concrete service. Then Launcher will use provided loader to encode instance config into bytes.

Also this PR adds a default `InstanceSpecLoader` (instead of `get_service_config` method) which will attempt to recursively parse the `Config` message.