### PR TITLE
Enhance cli & provide library interface [ECR-3628]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,41 @@ A tool to send deploy&init requests into the Exonum blockchain.
 ## Usage
 
 ```sh
-usage: python -m exonum_launcher run [-h] -i INPUT
+usage: exonum_launcher [-h] -i INPUT [-r RUNTIMES [RUNTIMES ...]]
+                       [--runtime-parsers RUNTIME_PARSERS [RUNTIME_PARSERS ...]]
+                       [--instance-parsers INSTANCE_PARSERS [INSTANCE_PARSERS ...]]
+
+Exonum service launcher
 
 optional arguments:
   -h, --help            show this help message and exit
   -i INPUT, --input INPUT
                         A path to yaml input for service initialization
+  -r RUNTIMES [RUNTIMES ...], --runtimes RUNTIMES [RUNTIMES ...]
+                        Additional runtimes, e.g. `--runtimes java=1 python=2
+                        wasm=3`
+  --runtime-parsers RUNTIME_PARSERS [RUNTIME_PARSERS ...]
+                        Runtime spec parsers, e.g. `--runtime-parsers
+                        python=your_module.YourRuntimeSpecLoader` Values will
+                        be imported and treated like SpecLoader, so ensure
+                        that module with loader is in `sys.path`.
+  --instance-parsers INSTANCE_PARSERS [INSTANCE_PARSERS ...]
+                        Instance spec parsers, e.g. `--runtime-parsers
+                        python=your_module.YourInstanceSpecLoader` Values will
+                        be imported and treated like InstanceSpecLoader, so
+                        ensure that module with loader is in `sys.path`.
+```
+
+So, if you want to run `exonum-launcher` with Rust runtime only and without custom artifact spec loaders, you can just use:
+
+```sh
+python3 -m exonum_launcher -i sample.yml
+```
+
+If you want to use `exonum-launcher` with Python runtime and Python runtime spec loader, the command will be:
+
+```sh
+python3 -m exonum_launcher --runtimes python=2 --runtime-parsers python=exonum_launcher.runtimes.python.PythonSpecLoader -i sample.yml
 ```
 
 Example of expected `yaml` file:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ instances:
     config: []
 ```
 
+Also you can define custom runtimes and plugins in the config (so you won't have to provide them from command line):
+
+```yaml
+runtimes:
+  python: 2
+
+plugins:
+  runtime:
+    python: "exonum_launcher.runtimes.python.PythonSpecLoader"
+  artifact: {}
+```
+
+See `samples` folder for more examples.
+
 ## Install
 
 I highly recommend to install this tool in the virtualenv.

--- a/exonum_launcher/__main__.py
+++ b/exonum_launcher/__main__.py
@@ -1,25 +1,6 @@
 """Exonum Launcher runner."""
-import argparse
-from .launcher import main as launcher_main
-
-
-def run() -> None:
-    """Parses arguments and runs the application."""
-    parser = argparse.ArgumentParser(prog="exonum_launcher", description="Exonum service launcher")
-    sub_parser = parser.add_subparsers(title="subcommands")
-
-    parser_run = sub_parser.add_parser("run", help="Runs the service launcher")
-    parser_run.add_argument(
-        "-i", "--input", type=str, help="A path to yaml input for service initialization", required=True
-    )
-    parser_run.set_defaults(func=launcher_main)
-
-    args = parser.parse_args()
-    if hasattr(args, "func"):
-        args.func(args)
-    else:
-        parser.print_help()
+from .cli import run_cli
 
 
 if __name__ == "__main__":
-    run()
+    run_cli()

--- a/exonum_launcher/cli.py
+++ b/exonum_launcher/cli.py
@@ -1,0 +1,46 @@
+"""CLI for exonum launcher"""
+import argparse
+from .launcher import main as launcher_main
+
+
+def run_cli() -> None:
+    """Parses arguments and runs the application."""
+    parser = argparse.ArgumentParser(prog="exonum_launcher", description="Exonum service launcher")
+
+    parser.add_argument(
+        "-i", "--input", type=str, help="A path to yaml input for service initialization", required=True
+    )
+
+    parser.add_argument(
+        "-r",
+        "--runtimes",
+        type=str,
+        nargs="+",
+        help="Additional runtimes, e.g. `--runtimes java=1 python=2 wasm=3`",
+        required=False,
+    )
+
+    parser.add_argument(
+        "--runtime-parsers",
+        type=str,
+        nargs="+",
+        help="""
+        Runtime spec parsers, e.g. `--runtime-parsers python=your_module.YourRuntimeSpecLoader`
+        Values will be imported and treated like SpecLoader, so ensure that module with loader is in `sys.path`.
+        """,
+        required=False,
+    )
+
+    parser.add_argument(
+        "--instance-parsers",
+        type=str,
+        nargs="+",
+        help="""
+        Instance spec parsers, e.g. `--runtime-parsers python=your_module.YourInstanceSpecLoader`
+        Values will be imported and treated like InstanceSpecLoader, so ensure that module with loader is in `sys.path`.
+        """,
+        required=False,
+    )
+
+    args = parser.parse_args()
+    launcher_main(args)

--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -66,9 +66,15 @@ class Configuration:
         return Configuration(data)
 
     def __init__(self, data: Dict[Any, Any]) -> None:
+        runtimes = data.get("runtimes")
+        if runtimes is not None:
+            for runtime in runtimes:
+                self.declare_runtime(runtime, runtimes[runtime])
+
         self.networks = data["networks"]
         self.artifacts: Dict[str, Artifact] = dict()
         self.instances: List[Instance] = list()
+        self.plugins: Dict[str, Dict[str, str]] = data.get("plugins", {"runtime": dict(), "artifact": dict()})
 
         # Imports configuration parser for each artifact.
         for name, value in data["artifacts"].items():

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -296,9 +296,9 @@ def run_launcher(
     instance_spec_loaders: Dict[str, InstanceSpecLoader],
 ) -> Dict[str, Any]:
     """Runs the launcher.
-    
+
     Returns the dict with two entries:
-    
+
     "artifacts" - contain a mapping `Artifact` => `bool denoting if artifact is deploted`
     "instances" - contain a mapping `Instance` => `Optional[InstanceId]`.
     """

--- a/run_examples.sh
+++ b/run_examples.sh
@@ -20,29 +20,10 @@ function prepare_launcher {
     echo "Exonum launcher env prepared"
 }
 
-function compile_proto {
-    python3 -m exonum-launcher \
-        compile \
-        -e $EXONUM_DIR \
-        -s $1 \
-        -o proto
-}
-
-function compile_protos {
-    compile_proto cryptocurrency:$EXONUM_DIR/examples/cryptocurrency-advanced/backend/src/proto/
-    compile_proto timestamping:$EXONUM_DIR/examples/timestamping/backend/src/proto/
-    compile_proto time:$EXONUM_DIR/services/time/src/proto/
-}
-
 function run_exonum_config {
     python -m exonum-launcher \
-        run \
-        -i $1 \
-        -p proto
+        -i $1
 }
-
-EXONUM_DIR=${VARIABLE:=../../exonum}
-EXONUM_DIR=$(abspath $EXONUM_DIR)
 
 TARGET_DIR=$(abspath $PWD)/target
 SOURCE_DIR=$(abspath $(dirname $0))
@@ -53,12 +34,10 @@ cd $TARGET_DIR
 prepare_launcher
 case "$1" in
     'timestamping')
-        compile_protos
         echo "Starting timestamping..."
         run_exonum_config $SOURCE_DIR/samples/timestamping.yml
     ;;
     'cryptocurrency')
-        compile_protos
         echo "Starting cryptocurrency..."
         run_exonum_config $SOURCE_DIR/samples/cryptocurrency-advanced.yml
     ;;

--- a/samples/plugins.yml
+++ b/samples/plugins.yml
@@ -1,0 +1,31 @@
+networks:
+  - host: "127.0.0.1"
+    ssl: false
+    public-api-port: 8080
+    private-api-port: 8081
+
+runtimes:
+  python: 2
+
+plugins:
+  runtime:
+    python: "exonum_launcher.runtimes.python.PythonSpecLoader"
+  artifact: {}
+
+deadline_height: 20000
+
+artifacts:
+  cryptocurrency:
+    runtime: python
+    name: "cryptocurrency"
+    spec:
+      source_wheel_name: "exonum-python-cryptocurrency-0.1.0.tar.gz"
+      service_library_name: "cryptocurrency"
+      service_class_name: "Cryptocurrency"
+      hash: "720fa5f8764998c8c1ae59ac83332aa931c9c53fbac5373d34118427fe5ef47e"
+  
+instances:
+  xnm-token:
+    artifact: cryptocurrency
+  nnm-token:
+    artifact: cryptocurrency


### PR DESCRIPTION
This PR introduces following changes:

- You can now add any runtimes and runtime/instance spec loaders right from command line, e.g.:
  ```sh
  python -m exonum_launcher --runtimes python=2 --runtime-parsers python=exonum_launcher.runtimes.python.PythonSpecLoader -i sample.yml
  ```

- Main runner function is now not nailed to CLI. It now has the following signature:

  ```python
  def run_launcher(
      config: Configuration,
      runtime_spec_loaders: Dict[str, RuntimeSpecLoader],
      instance_spec_loaders: Dict[str, InstanceSpecLoader],
  ) -> Dict[str, Any]
  ```

  So you configure the launcher as you want and get results in the `dict`. It may be useful for writing integration tests later.

**Updated**: By request of @alekseysidorov I added a possibility to specify plugins in the config, e.g.:

```yaml
runtimes:
  python: 2

plugins:
  runtime:
    python: "exonum_launcher.runtimes.python.PythonSpecLoader"
  artifact: {}
```

So you won't have to deal with command-line arguments.