### PR TITLE
Update requirements.txt to use current master of client & --no-binary=protobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See `samples` folder for more examples.
 ## Install
 
 ```sh
-pip install exonum-launcher
+pip install exonum-launcher --no-binary=protobuf
 ```
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ PyYAML==5.1.2
 requests==2.22.0
 six==1.12.0
 urllib3==1.25.3
--e git+https://github.com/exonum/exonum-python-client@f30b5588653f05aa2a525d796b33ff55d6f655fd#egg=exonum-python-client
+-e git+https://github.com/exonum/exonum-python-client@master#egg=exonum-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 certifi==2019.6.16
 chardet==3.0.4
 idna==2.8
-protobuf==3.9.1
+protobuf==3.9.2 --no-binary=protobuf
 pysodium==0.7.2
 PyYAML==5.1.2
 requests==2.22.0
 six==1.12.0
 urllib3==1.25.3
-exonum-python-client==0.4.0.dev2
+-e git+https://github.com/exonum/exonum-python-client@f30b5588653f05aa2a525d796b33ff55d6f655fd#egg=exonum-python-client


### PR DESCRIPTION
This PR makes dependencies installed from requirements.txt:
1. use --no-binary=protobuf by default.
2. use `exonum-client` from git current master.

Install via setup.py should use pip install -e . --no-binary=protobuf, and will depend on `exonum-client` release still though.