### PR TITLE
Support config changing and service stop [ECR-3781]

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,50 @@ artifacts:
 instances:
   xnm-token:
     artifact: cryptocurrency
+    action: start
     config: []
   nnm-token:
     artifact: "cryptocurrency"
+    action: start
     config: []
   some-instance:
     # Since we will not deploy `example_artifact`, it is assumed that it is already deployed
     artifact: "example_artifact"
+    action: start
     config:
       val_a: "123"
       val_b: 345
 ```
+
+`action` field can be one of the following:
+
+- `start`: to start a new instance;
+- `config` to change a configuration of existing service (only in `simple` supervisor mode!);
+- `stop` to stop a running service.
 
 **Important:** if you have more than one validator in the network, ensure that connection data
 (`networks` section of the config) is specified for **every** validator.
 
 Deploy&init process requires requests to be sent to each validator, so don't expect that transaction broadcast
 mechanism will work here.
+
+If supervisor works in the `simple` mode, it's also possible to change consensus config
+by providing a `consensus` field in the config, for example:
+
+```yaml
+consensus:
+    validator_keys:
+      - ["1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",
+         "2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b"]
+    first_round_timeout: 100
+    status_timeout: 100
+    peers_timeout: 100
+    txs_block_limit: 100
+    max_message_len: 100
+    min_propose_timeout: 100
+    max_propose_timeout: 100
+    propose_timeout_threshold: 100
+```
 
 ## Plugins
 

--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -134,7 +134,7 @@ class Configuration:
         for key_pair in self.consensus["validator_keys"]:
             if len(key_pair) != 2:
                 raise RuntimeError(
-                    "Validaor keys should be a list of pairs (consensus_key, service_key) in hexadecimal form"
+                    "Validator keys should be a list of pairs (consensus_key, service_key) in hexadecimal form"
                 )
 
             # Check that keys can be parsed correctly.

--- a/exonum_launcher/instances/instance_spec_loader.py
+++ b/exonum_launcher/instances/instance_spec_loader.py
@@ -1,6 +1,7 @@
 """Module with base class for Instance spec loader plugins."""
 
 import abc
+from typing import Any
 
 from exonum_client.protobuf_loader import ProtobufLoader
 
@@ -18,3 +19,13 @@ class InstanceSpecLoader(metaclass=abc.ABCMeta):
     def load_spec(self, loader: ProtobufLoader, instance: Instance) -> bytes:
         """This method gets an instance spec and Protobuf Loader object and
         must provide instance spec serialized to bytes."""
+
+    # pylint: disable=no-self-use
+    def serialize_config(self, _loader: ProtobufLoader, _instance: Instance, _config: Any) -> bytes:
+        """This methods gets an instance spec, Protobuf Loader object and
+        configuration data, and must provide message for service configuration
+        change serialized to bytes.
+
+        This method is optional and has a empty implementation by default."""
+
+        return b""

--- a/exonum_launcher/launch_state.py
+++ b/exonum_launcher/launch_state.py
@@ -2,7 +2,7 @@
 from typing import Dict, List
 
 from .action_result import ActionResult
-from .configuration import Artifact, Instance
+from .configuration import Artifact, Instance, Configuration
 
 
 class LaunchState:
@@ -10,41 +10,41 @@ class LaunchState:
 
     def __init__(self) -> None:
         self._pending_deployments: Dict[Artifact, List[str]] = dict()
-        self._pending_initializations: Dict[Instance, List[str]] = dict()
+        self._pending_configs: Dict[Configuration, List[str]] = dict()
         self._completed_deployments: Dict[Artifact, ActionResult] = dict()
-        self._completed_initializations: Dict[Instance, ActionResult] = dict()
+        self._completed_configs: Dict[Configuration, ActionResult] = dict()
 
     def add_pending_deploy(self, artifact: Artifact, txs: List[str]) -> None:
         """Adds a pending deploy to the state."""
         self._pending_deployments[artifact] = txs
 
-    def add_pending_initialization(self, instance: Instance, txs: List[str]) -> None:
-        """Adds a pending initialization to the state."""
-        self._pending_initializations[instance] = txs
+    def add_pending_config(self, config: Configuration, txs: List[str]) -> None:
+        """Adds a pending config to the state."""
+        self._pending_configs[config] = txs
 
     def pending_deployments(self) -> Dict[Artifact, List[str]]:
         """Returns a copy of pending deployments dict."""
         return dict(self._pending_deployments)
 
-    def pending_initializations(self) -> Dict[Instance, List[str]]:
+    def pending_configs(self) -> Dict[Configuration, List[str]]:
         """Returns a copy of pending initializations dict."""
-        return dict(self._pending_initializations)
+        return dict(self._pending_configs)
 
     def complete_deploy(self, artifact: Artifact, result: ActionResult) -> None:
         """Completes the deploy process."""
         self._completed_deployments[artifact] = result
         del self._pending_deployments[artifact]
 
-    def complete_initialization(self, instance: Instance, result: ActionResult) -> None:
-        """Completes the initialization process."""
-        self._completed_initializations[instance] = result
-        if instance in self._pending_initializations:
-            del self._pending_initializations[instance]
+    def complete_config(self, config: Configuration, result: ActionResult) -> None:
+        """Adds a pending config to the state."""
+        self._completed_configs[config] = result
+        if config in self._pending_configs:
+            del self._pending_configs[config]
 
     def completed_deployments(self) -> Dict[Artifact, ActionResult]:
         """Returns a copy of completed deployments dict."""
         return dict(self._completed_deployments)
 
-    def completed_initializations(self) -> Dict[Instance, ActionResult]:
-        """Returns a copy of completed initializations dict."""
-        return dict(self._completed_initializations)
+    def completed_configs(self) -> Dict[Configuration, ActionResult]:
+        """Returns a copy of completed configs dict."""
+        return dict(self._completed_configs)

--- a/exonum_launcher/launch_state.py
+++ b/exonum_launcher/launch_state.py
@@ -2,7 +2,7 @@
 from typing import Dict, List
 
 from .action_result import ActionResult
-from .configuration import Artifact, Instance, Configuration
+from .configuration import Artifact, Configuration
 
 
 class LaunchState:

--- a/exonum_launcher/main.py
+++ b/exonum_launcher/main.py
@@ -2,6 +2,7 @@
 import sys
 from typing import Any, Dict
 
+from .action_result import ActionResult
 from .configuration import Configuration
 from .launcher import Launcher
 
@@ -31,16 +32,25 @@ def run_launcher(config: Configuration) -> Dict[str, Any]:
             deployed = explorer.check_deployed(artifact)
             results["artifacts"][artifact] = deployed
             deployed_str = "succeed" if deployed else "failed"
-            print("Artifact {} -> deploy status: {}".format(artifact.name, deployed_str))
+            print(f"Artifact {artifact.name} -> deploy status: {deployed_str}")
 
         launcher.start_all()
         launcher.wait_for_start()
 
-        for instance in launcher.launch_state.completed_initializations():
-            instance_id = explorer.get_instance_id(instance)
-            results["instances"][instance] = instance_id
-            id_str = "started with ID {}".format(instance_id) if instance_id else "start failed"
-            print("Instance {} -> start status: {}".format(instance.name, id_str))
+        config_state = launcher.launch_state.completed_configs()[launcher.config]
+        if config_state == ActionResult.Fail:
+            print("Applying of config -> FAIL")
+
+        for instance in launcher.config.instances:
+            if instance.action == "start":
+                instance_id = explorer.get_instance_id(instance)
+                results["instances"][instance] = instance_id
+                id_str = "started with ID {}".format(instance_id) if instance_id else "start failed"
+                print(f"Instance {instance.name} -> start status: {id_str}")
+            elif instance.action == "stop":
+                print(f"Instance {instance.name} stopped")
+            elif instance.action == "config":
+                print(f"Instance {instance.name} -> config '{instance.config}' applied")
 
         return results
 

--- a/samples/cryptocurrency-advanced.yml
+++ b/samples/cryptocurrency-advanced.yml
@@ -21,5 +21,7 @@ artifacts:
 instances:
   xnm-token:
     artifact: cryptocurrency
+    action: start
   nnm-token:
-    artifact: "cryptocurrency"
+    artifact: cryptocurrency
+    action: start

--- a/samples/plugins.yml
+++ b/samples/plugins.yml
@@ -30,5 +30,7 @@ artifacts:
 instances:
   xnm-token:
     artifact: cryptocurrency
+    action: start
   nnm-token:
     artifact: cryptocurrency
+    action: start

--- a/samples/timestamping.yml
+++ b/samples/timestamping.yml
@@ -21,8 +21,10 @@ artifacts:
 instances:
   time:
     artifact: time
+    action: start
   timestamping:
     artifact: timestamping
+    action: start
     config:
       time_service_name: "time"
       time_service_id: 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,11 @@ class TestConfiguration(unittest.TestCase):
         }
 
         self.assertEqual(config.plugins, expected_layout)
+
+    def test_parse_consensus(self) -> None:
+        config = self.load_config("consensus.yml")
+
+        self.assertIsNotNone(config.consensus)
+        self.assertEqual(len(config.consensus["validator_keys"]), 1)
+        self.assertEqual(len(config.consensus["validator_keys"][0]), 2)
+        self.assertEqual(config.consensus["first_round_timeout"], 100)

--- a/tests/test_data/consensus.yml
+++ b/tests/test_data/consensus.yml
@@ -1,0 +1,23 @@
+networks:
+  - host: "127.0.0.1"
+    ssl: false
+    public-api-port: 8080
+    private-api-port: 8081
+
+deadline_height: 20000
+
+consensus:
+    validator_keys: 
+      - ["1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",
+         "2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b"]
+    first_round_timeout: 100
+    status_timeout: 100
+    peers_timeout: 100
+    txs_block_limit: 100
+    max_message_len: 100
+    min_propose_timeout: 100
+    max_propose_timeout: 100
+    propose_timeout_threshold: 100
+
+artifacts: {}
+instances: {}

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -177,20 +177,19 @@ class TestLauncher(unittest.TestCase):
             launcher._artifact_plugins.get(instance.artifact, MockDefaultInstanceSpecLoader())
             for instance in config.instances
         ]
-        start_calls_sequence.append(call(config.instances, spec_loaders, config.actual_from))
+        start_calls_sequence.append(call(None, config.instances, spec_loaders, config.actual_from))
         send_calls_sequence.append(call(b"123"))
 
         # Mock methods.
-        launcher._supervisor.create_start_instances_request = MagicMock(return_value=b"123")  # type: ignore
+        launcher._supervisor.create_config_change_request = MagicMock(return_value=b"123")  # type: ignore
         launcher._supervisor.send_propose_config_request = MagicMock(return_value=["123"])  # type: ignore
 
         # Call start.
         launcher.start_all()
 
         # Check that methods were invoked with the expected arguments and in the expected order.
-        launcher._supervisor.create_start_instances_request.assert_has_calls(start_calls_sequence)  # type: ignore
+        launcher._supervisor.create_config_change_request.assert_has_calls(start_calls_sequence)  # type: ignore
         launcher._supervisor.send_propose_config_request.assert_has_calls(send_calls_sequence)  # type: ignore
 
-        # Check that results were added to the pending deployments.
-        for instance in config.instances:
-            self.assertEqual(launcher.launch_state._pending_initializations[instance], ["123"])
+        # Check that results were added to the pending configs.
+        self.assertEqual(launcher.launch_state._pending_configs[launcher.config], ["123"])


### PR DESCRIPTION
It is now possible to change service config or stop service instance in `exonum-launcher` (only in `simple` mode yet).

`InstanceSpecLoader` obtained a new method `serialize_config` for serializing configs for config change request.

Now launcher config can look as the following:

```yaml
#...

instances:
  xnm-token:
    artifact: cryptocurrency
    action: start # <- start instance (default, works the same as before)
  nnm-token:
    artifact: cryptocurrency
    action: stop # <- stop service instance (service ID will be deduced by launcher)
  configuration:
    artifact: configuration
    action: config # <- change config
    config:
       mode: 1
```