### PR TITLE
Specify the compatible exonum-python-client revision [ECR-4293]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ jobs:
       - pylint exonum_launcher --max-line-length=120 --disable=fixme,bad-continuation,too-few-public-methods,duplicate-code
   - name: tests
     install:
-      - pip install --no-binary=protobuf protobuf pysodium requests websocket-client-py3 PyYAML
-      - git clone https://github.com/exonum/exonum-python-client.git
-      - pip install -e exonum-python-client
+      - pip install -r requirements.txt
     script:
       - python -m unittest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ PyYAML==5.1.2
 requests==2.22.0
 six==1.12.0
 urllib3==1.25.3
-# Use an editable git dependency on exonum-python-client till it is released.
-# Update the specified revision whenever a new version is required.
+# Update the specified exonum-python-client revision whenever a new version is required.
 -e git+https://github.com/exonum/exonum-python-client@321282c110897d8e24fa087e3978cc49b5a5842b#egg=exonum-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,6 @@ PyYAML==5.1.2
 requests==2.22.0
 six==1.12.0
 urllib3==1.25.3
--e git+https://github.com/exonum/exonum-python-client@master#egg=exonum-python-client
+# Use an editable git dependency on exonum-python-client till it is released.
+# Update the specified revision whenever a new version is required.
+-e git+https://github.com/exonum/exonum-python-client@321282c110897d8e24fa087e3978cc49b5a5842b#egg=exonum-python-client


### PR DESCRIPTION
 Specify the compatible exonum-python-client revision.

The master does not necessarily contain the compatible
revision, making the requirements configuration less
reliable.

See: 
 - exonum/exonum-python-client@321282c

