### PR TITLE
Allow to omit each plugin type declaration: [ECR-4315]

### DIFF
--- a/exonum_launcher/configuration.py
+++ b/exonum_launcher/configuration.py
@@ -95,7 +95,15 @@ class Configuration:
         self.actual_from = data.get("actual_from", 0)
         self.artifacts: Dict[str, Artifact] = dict()
         self.instances: List[Instance] = list()
-        self.plugins: Dict[str, Dict[str, str]] = data.get("plugins", {"runtime": dict(), "artifact": dict()})
+
+        # Init the plugins
+        plugin_types: List[str] = ["runtime", "artifact"]
+        self.plugins: Dict[str, Dict[str, str]] = data.get("plugins", dict())
+        # Add the plugin types
+        for plugin_type in plugin_types:
+            if plugin_type not in self.plugins.keys():
+                self.plugins[plugin_type] = dict()
+
         self.consensus: Any = data.get("consensus", None)
 
         if self.consensus is not None:

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -52,10 +52,7 @@ class Launcher:
 
     def _load_runtime_plugins(self) -> Dict[str, RuntimeSpecLoader]:
         runtime_loaders: Dict[str, RuntimeSpecLoader] = dict()
-        plugins = self.config.plugins
-        if "runtime" not in plugins:
-            return runtime_loaders
-        for runtime_name, class_path in plugins["runtime"].items():
+        for runtime_name, class_path in self.config.plugins["runtime"].items():
             try:
                 runtime_loaders[runtime_name] = _import_class(class_path, RuntimeSpecLoader)
             except (ValueError, ImportError, ModuleNotFoundError, AttributeError) as error:
@@ -65,10 +62,7 @@ class Launcher:
 
     def _load_artifact_plugins(self) -> Dict[Artifact, InstanceSpecLoader]:
         instance_loaders: Dict[Artifact, InstanceSpecLoader] = dict()
-        plugins = self.config.plugins
-        if "artifact" not in plugins:
-            return instance_loaders
-        for artifact_name, class_path in plugins["artifact"].items():
+        for artifact_name, class_path in self.config.plugins["artifact"].items():
             try:
                 artifact = self.config.artifacts[artifact_name]
                 instance_loaders[artifact] = _import_class(class_path, InstanceSpecLoader)

--- a/exonum_launcher/launcher.py
+++ b/exonum_launcher/launcher.py
@@ -52,7 +52,10 @@ class Launcher:
 
     def _load_runtime_plugins(self) -> Dict[str, RuntimeSpecLoader]:
         runtime_loaders: Dict[str, RuntimeSpecLoader] = dict()
-        for runtime_name, class_path in self.config.plugins["runtime"].items():
+        plugins = self.config.plugins
+        if "runtime" not in plugins:
+            return runtime_loaders
+        for runtime_name, class_path in plugins["runtime"].items():
             try:
                 runtime_loaders[runtime_name] = _import_class(class_path, RuntimeSpecLoader)
             except (ValueError, ImportError, ModuleNotFoundError, AttributeError) as error:
@@ -62,7 +65,10 @@ class Launcher:
 
     def _load_artifact_plugins(self) -> Dict[Artifact, InstanceSpecLoader]:
         instance_loaders: Dict[Artifact, InstanceSpecLoader] = dict()
-        for artifact_name, class_path in self.config.plugins["artifact"].items():
+        plugins = self.config.plugins
+        if "artifact" not in plugins:
+            return instance_loaders
+        for artifact_name, class_path in plugins["artifact"].items():
             try:
                 artifact = self.config.artifacts[artifact_name]
                 instance_loaders[artifact] = _import_class(class_path, InstanceSpecLoader)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,16 @@ class TestConfiguration(unittest.TestCase):
 
         self.assertEqual(config.plugins, expected_layout)
 
+    def test_parse_plugins_runtime_only(self) -> None:
+        config = self.load_config("custom_plugins_runtime_only.yml")
+
+        expected_layout = {
+            "runtime": {"sample3": "tests.spec_loaders.TestRuntimeSpecLoader"},
+            "artifact": {},
+        }
+
+        self.assertEqual(config.plugins, expected_layout)
+
     def test_parse_consensus(self) -> None:
         config = self.load_config("consensus.yml")
 

--- a/tests/test_data/custom_plugins_runtime_only.yml
+++ b/tests/test_data/custom_plugins_runtime_only.yml
@@ -1,0 +1,26 @@
+networks:
+  - host: "127.0.0.1"
+    ssl: false
+    public-api-port: 8080
+    private-api-port: 8081
+
+runtimes:
+  sample3: 3
+
+plugins:
+  runtime:
+    sample3: "tests.spec_loaders.TestRuntimeSpecLoader"
+
+deadline_height: 20000
+
+artifacts:
+  cryptocurrency:
+    runtime: sample
+    name: "cryptocurrency"
+    version: "1.0.0"
+    spec:
+      parameter: "value"
+
+instances:
+  xnm-token:
+    artifact: cryptocurrency

--- a/tests/test_data/custom_plugins_runtime_only.yml
+++ b/tests/test_data/custom_plugins_runtime_only.yml
@@ -15,7 +15,7 @@ deadline_height: 20000
 
 artifacts:
   cryptocurrency:
-    runtime: sample
+    runtime: sample3
     name: "cryptocurrency"
     version: "1.0.0"
     spec:

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -127,6 +127,14 @@ class TestLauncher(unittest.TestCase):
         self.assertEqual(type(launcher._runtime_plugins["sample"]), TestRuntimeSpecLoader)
         self.assertEqual(type(launcher._artifact_plugins[cryptocurrency]), TestInstanceSpecLoader)
 
+    def test_load_plugins_runtime_only(self) -> None:
+        """Tests that plugins are loaded as expected if only the runtime plugins are present: no artifact plugins"""
+        config = TestConfiguration.load_config("custom_plugins_runtime_only.yml")
+
+        launcher = Launcher(config)
+        self.assertEqual(type(launcher._runtime_plugins["rust"]), RustSpecLoader)
+        self.assertEqual(type(launcher._runtime_plugins["sample3"]), TestRuntimeSpecLoader)
+
     def test_deploy_all(self) -> None:
         """Tests that deploy method uses supervisor to deploy all artifacts from config."""
         config = TestConfiguration.load_config("sample_config.yml")


### PR DESCRIPTION
Previously one had to specify all plugin types
(runtime & artifact) even if they needed only
a single one; and got an obscure error if
they missed one.